### PR TITLE
Fix Error in RPT - currentMuzzle not always return a string

### DIFF
--- a/@ExileServer/addons/a3_dms/scripts/fn_OnKilled.sqf
+++ b/@ExileServer/addons/a3_dms/scripts/fn_OnKilled.sqf
@@ -282,13 +282,13 @@ if (isPlayer _killer) then
 	if (DMS_ai_share_info) then
 	{
 		_revealAmount = 4.0;
-
-		_silencer = _playerObj weaponAccessories currentMuzzle _playerObj select 0;
-		if (!isNil "_silencer" && {_silencer != ""}) then
-		{
-			_revealAmount = 2.0;
+		if (!isNumber(currentMuzzle _playerObj)) then {
+			_silencer = _playerObj weaponAccessories currentMuzzle _playerObj select 0;
+			if (!isNil "_silencer" && {_silencer != ""}) then
+			{
+				_revealAmount = 2.0;
+			};
 		};
-
 
 		{
 			if ((alive _x) && {!(isPlayer _x) && {((getPosWorld _x) distance2D (getPosWorld _unit)) <= DMS_ai_share_info_distance}}) then


### PR DESCRIPTION
https://community.bistudio.com/wiki/currentMuzzle

The return value is not always STRING. As of Arma 3 v1.36, this command returns 0 (NUMBER) for vehicles.

E.g. when inside a vehicle:
currentMuzzle vehicle player
-> 0 

CAUSES

18:05:48 Error in expression <alAmount = 4.0;

_silencer = _playerObj weaponAccessories currentMuzzle _playerO>
18:05:48 Error position:
18:05:48 Error weaponaccessories: Type Number, expected String
18:05:48 File x\addons\dms\scripts\fn_OnKilled.sqf, line 286
