### PR TITLE
Initial mission delay at server startup

### DIFF
--- a/@ExileServer/addons/a3_dms/config.sqf
+++ b/@ExileServer/addons/a3_dms/config.sqf
@@ -26,6 +26,7 @@ DMS_Use_Map_Config = true;	// Whether or not to use config overwrites specific t
 	DMS_MaxBanditMissions				= 3;						// Maximum number of Bandit Missions running at the same time
 	DMS_StaticMission					= false;					// Enable/disable static missions
 	DMS_TimeBetweenMissions				= [600,900];				// [Minimum,Maximum] time between missions (if mission limit is not reached) | DEFAULT: 10-15 mins
+	DMS_InitialDelay = 180; // Initial mission delay at server startup
 	DMS_MissionTimeOut					= [900,1800]; 				// [Minimum,Maximum] time it will take for a mission to timeout | Default: 15-30 mins
 	/*General settings for dynamic missions*/
 

--- a/@ExileServer/addons/a3_dms/missions/mission_init.sqf
+++ b/@ExileServer/addons/a3_dms/missions/mission_init.sqf
@@ -14,6 +14,7 @@ DMS_MissionCount 				= 0;
 DMS_RunningBMissionCount		= 0;
 DMS_BMissionLastStart			= diag_tickTime;
 DMS_BMissionDelay 				= DMS_TimeBetweenMissions call DMS_fnc_SelectRandomVal;
+DMS_InitStart = DMS_BMissionLastStart;
 
 
 if (DMS_DEBUG) then

--- a/@ExileServer/addons/a3_dms/scripts/fn_SelectMission.sqf
+++ b/@ExileServer/addons/a3_dms/scripts/fn_SelectMission.sqf
@@ -17,7 +17,7 @@ if (DMS_RunningBMissionCount >= DMS_MaxBanditMissions) then
 if (diag_fps >= DMS_MinServerFPS && {(count allPlayers) >= DMS_MinPlayerCount}) then
 {
 	// More Mission types coming soon
-	if (_time - DMS_BMissionLastStart > DMS_BMissionDelay) then
+	if (_time - DMS_BMissionLastStart > DMS_BMissionDelay || (DMS_InitStart == DMS_BMissionLastStart && _time - DMS_BMissionLastStart > DMS_InitialDelay)) then
 	{
 		private "_mission";
 		_mission = DMS_BanditMissionTypesArray call BIS_fnc_selectRandom;


### PR DESCRIPTION
This simple change adds a user config value for an initial mission delay at server startup.  For example: if you'd like your time between missions to be between 10 and 15 minutes, that means you will also have to wait between 10 and 15 minutes after initial server startup for the first mission to start.  This edit will allow you to set a "one-time" mission delay value/check to make that first mission spawn sooner after a server restart.
