### PR TITLE
Make Launcher selection random on AI spawn

### DIFF
--- a/@ExileServer/addons/a3_dms/scripts/fn_SpawnAIGroup.sqf
+++ b/@ExileServer/addons/a3_dms/scripts/fn_SpawnAIGroup.sqf
@@ -82,11 +82,6 @@ for "_i" from 1 to _count do
 // An AI will definitely spawn with a launcher if you define type
 if ((!isNil "_launcherType") || {DMS_ai_use_launchers && {DMS_ai_launchers_per_group>0}}) then
 {
-	if (isNil "_launcherType") then
-	{
-		_launcherType = "AT";
-	};
-
 	_units = units _group;
 
 	for "_i" from 0 to (((DMS_ai_launchers_per_group min _count)-1) max 0) do
@@ -95,7 +90,12 @@ if ((!isNil "_launcherType") || {DMS_ai_use_launchers && {DMS_ai_launchers_per_g
 		{
 			_unit = _units select _i;
 
-			_launcher = ((missionNamespace getVariable [format ["DMS_AI_wep_launchers_%1",_launcherType],["launch_NLAW_F"]]) call BIS_fnc_selectRandom);
+			if (isNil "_launcherType") then
+			{
+				_launcherType = selectRandom ["AT","AA"];
+			};
+
+			_launcher = (selectRandom (missionNamespace getVariable [format ["DMS_AI_wep_launchers_%1",_launcherType],["launch_NLAW_F"]]));
 
 			removeBackpackGlobal _unit;
 			_unit addBackpack "B_Carryall_mcamo";
@@ -104,7 +104,7 @@ if ((!isNil "_launcherType") || {DMS_ai_use_launchers && {DMS_ai_launchers_per_g
 			[_unit, _launcher, DMS_AI_launcher_ammo_count,_rocket] call BIS_fnc_addWeapon;
 
 			_unit setVariable ["DMS_AI_Launcher",_launcher];
-			
+
 			if (DMS_DEBUG) then
 			{
 				(format["SpawnAIGroup :: Giving %1 a %2 launcher with %3 %4 rockets",_unit,_launcher,DMS_AI_launcher_ammo_count,_rocket]) call DMS_fnc_DebugLog;

--- a/@ExileServer/addons/a3_dms/scripts/fn_SpawnAIGroup_MultiPos.sqf
+++ b/@ExileServer/addons/a3_dms/scripts/fn_SpawnAIGroup_MultiPos.sqf
@@ -99,10 +99,6 @@ for "_i" from 1 to _count do
 // An AI will definitely spawn with a launcher if you define type
 if ((!isNil "_launcherType") || {DMS_ai_use_launchers && {DMS_ai_launchers_per_group>0}}) then
 {
-	if (isNil "_launcherType") then
-	{
-		_launcherType = "AT";
-	};
 
 	_units = units _group;
 
@@ -111,6 +107,11 @@ if ((!isNil "_launcherType") || {DMS_ai_use_launchers && {DMS_ai_launchers_per_g
 		if ((random 100)<DMS_ai_use_launchers_chance) then
 		{
 			_unit = _units select _i;
+
+			if (isNil "_launcherType") then
+			{
+				_launcherType = selectRandom ["AT","AA"];
+			};
 
 			_launcher = ((missionNamespace getVariable [format ["DMS_AI_wep_launchers_%1",_launcherType],["launch_NLAW_F"]]) call BIS_fnc_selectRandom);
 


### PR DESCRIPTION
this change will make AI Launcher selection random on each unit spawn, rather than the hard coded only AT
