### PR TITLE
Added DMS_fnc_TargetsKilledPercent function, to check % of alive bots

### DIFF
--- a/@ExileServer/addons/a3_dms/config.cpp
+++ b/@ExileServer/addons/a3_dms/config.cpp
@@ -90,6 +90,7 @@ class CfgFunctions
 			class SpawnStaticMission			{};
 			class SubArr						{};
 			class TargetsKilled 				{};
+			class TargetsKilledPercent 				{};
 		};
 	};
 };

--- a/@ExileServer/addons/a3_dms/missions/bandit/bandits.sqf
+++ b/@ExileServer/addons/a3_dms/missions/bandit/bandits.sqf
@@ -133,7 +133,7 @@ _markers =
 // Record time here (for logging purposes, otherwise you could just put "diag_tickTime" into the "DMS_AddMissionToMonitor" parameters directly)
 _time = diag_tickTime;
 
-private _initialUnitCount = _AICount; //Get inital count of bots then mission starts. It need only for "killpercent" condnition. Look for deatiled info in DMS_fnc_TargetsKilledPercent
+private _initialUnitCount = count (_group call DMS_fnc_GetAllUnits); //Get inital count of bots then mission starts. It need only for "killpercent" condnition. Look for detailed info in DMS_fnc_TargetsKilledPercent
 
 // Parse and add mission info to missions monitor
 _added =

--- a/@ExileServer/addons/a3_dms/missions/bandit/bandits.sqf
+++ b/@ExileServer/addons/a3_dms/missions/bandit/bandits.sqf
@@ -133,6 +133,8 @@ _markers =
 // Record time here (for logging purposes, otherwise you could just put "diag_tickTime" into the "DMS_AddMissionToMonitor" parameters directly)
 _time = diag_tickTime;
 
+private _initialUnitCount = _AICount; //Get inital count of bots then mission starts. It need only for "killpercent" condnition. Look for deatiled info in DMS_fnc_TargetsKilledPercent
+
 // Parse and add mission info to missions monitor
 _added =
 [
@@ -140,7 +142,7 @@ _added =
 	[
 		[
 			"killpercent",
-			_group
+      [_initialUnitCount, _group]
 		],
 		[
 			"playerNear",

--- a/@ExileServer/addons/a3_dms/missions/bandit/bandits.sqf
+++ b/@ExileServer/addons/a3_dms/missions/bandit/bandits.sqf
@@ -139,7 +139,7 @@ _added =
 	_pos,
 	[
 		[
-			"kill",
+			"killpercent",
 			_group
 		],
 		[

--- a/@ExileServer/addons/a3_dms/scripts/fn_GetAllUnits.sqf
+++ b/@ExileServer/addons/a3_dms/scripts/fn_GetAllUnits.sqf
@@ -2,7 +2,6 @@
 	DMS_fnc_GetAllUnits
 	Created by eraser1
 
-
 	Usage:
 	[
 		_unitOrGroupOrArray1,
@@ -14,12 +13,14 @@
 	Returns all living units from a given array of groups or objects.
 */
 
-if !(_this isEqualType []) then
-{
+if !(_this isEqualType []) then {
 	_this = [_this];
 };
 
 private _units = [];
+private _footUnits = [];
+private _vehicleUnits = [];
+private _staticUnits = [];
 
 {
 	private _parameter = _x;
@@ -35,10 +36,18 @@ private _units = [];
 
 			case "OBJECT":
 			{
-				[
-					[],
-					[_parameter]
-				] select (alive _parameter);
+				if (alive _parameter) then {
+					if (_parameter isKindOf "LandVehicle" || _parameter isKindOf "Air" || _parameter isKindOf "Ship") then {
+						_vehicleUnits append (crew _parameter select {alive _x});
+					} else if (_parameter isKindOf "StaticWeapon") then {
+						_staticUnits append (crew _parameter select {alive _x});
+					} else {
+						_footUnits pushBack _parameter;
+					};
+					[_parameter];
+				} else {
+					[];
+				};
 			};
 
 			case "GROUP":
@@ -55,10 +64,11 @@ private _units = [];
 	);
 } forEach _this;
 
-if (DMS_DEBUG) then
-{
-	(format ["GetAllUnits :: Input (%1) produced units: %2",_this,_units]) call DMS_fnc_DebugLog;
+if (DMS_DEBUG) then {
+	diag_log format ["GetAllUnits :: Foot units: %1", _footUnits];
+	diag_log format ["GetAllUnits :: Vehicle units: %1", _vehicleUnits];
+	diag_log format ["GetAllUnits :: Static units: %1", _staticUnits];
+	diag_log format ["GetAllUnits :: Total units: %1", _units];
 };
-
 
 _units

--- a/@ExileServer/addons/a3_dms/scripts/fn_GetAllUnits.sqf
+++ b/@ExileServer/addons/a3_dms/scripts/fn_GetAllUnits.sqf
@@ -1,6 +1,7 @@
 /*
 	DMS_fnc_GetAllUnits
 	Created by eraser1
+	Modified by Ravenger2709
 
 	Usage:
 	[

--- a/@ExileServer/addons/a3_dms/scripts/fn_MissionSuccessState.sqf
+++ b/@ExileServer/addons/a3_dms/scripts/fn_MissionSuccessState.sqf
@@ -35,6 +35,8 @@ private _exit = false;
             throw "ERROR";
         };
 
+        private _completionType = _x select 0;
+        private _completionArgs = _x select 1;
         private _absoluteWinCondition = _x param [2, false, [true]];
 
         if (!_success && {!_absoluteWinCondition}) then
@@ -51,21 +53,21 @@ private _exit = false;
         {
             case "kill":
             {
-                _success = _completionArgs call DMS_fnc_TargetsKilled;
+                _success = _success && (_completionArgs call DMS_fnc_TargetsKilled);
             };
             
             case "killpercent":
             {
-                _success = _completionArgs call DMS_fnc_TargetsKilledPercent;
+                _success = _success && (_completionArgs call DMS_fnc_TargetsKilledPercent);
             };
             
             case "playernear":
             {
-                _success = _completionArgs call DMS_fnc_IsPlayerNearby;
+                _success = _success && (_completionArgs call DMS_fnc_IsPlayerNearby);
             };
-            case "external":
+            case "external":            // This is a special completion type. It is intended to be a flag for people who want to control mission completion using _onMonitorStart and _onMonitorEnd through array manipulation. You probably don't want to use this unless you know what you're doing.
             {
-                _success = _completionArgs;
+                _success = _success && _completionArgs;
             };
             default
             {

--- a/@ExileServer/addons/a3_dms/scripts/fn_MissionSuccessState.sqf
+++ b/@ExileServer/addons/a3_dms/scripts/fn_MissionSuccessState.sqf
@@ -1,6 +1,7 @@
 /*
     DMS_fnc_MissionSuccessState
     Created by eraser1
+    Modified by Ravenger2709
 
     Usage:
     [

--- a/@ExileServer/addons/a3_dms/scripts/fn_MissionSuccessState.sqf
+++ b/@ExileServer/addons/a3_dms/scripts/fn_MissionSuccessState.sqf
@@ -35,6 +35,8 @@ private _exit = false;
             throw "ERROR";
         };
 
+        private _completionType = _x select 0;
+        private _completionArgs = _x select 1;
         private _absoluteWinCondition = _x param [2, false, [true]];
 
         if (!_success && {!_absoluteWinCondition}) then

--- a/@ExileServer/addons/a3_dms/scripts/fn_MissionSuccessState.sqf
+++ b/@ExileServer/addons/a3_dms/scripts/fn_MissionSuccessState.sqf
@@ -55,12 +55,12 @@ private _exit = false;
 			{
 				_success = _completionArgs call DMS_fnc_TargetsKilled;
 			};
-			/*
+			
 			case "killpercent":
 			{
-				_success = _completionArgs call DMS_fnc_TargetsKilledPercent;//<---TODO
+				_success = _completionArgs call DMS_fnc_TargetsKilledPercent;
 			};
-			*/
+			
 			case "playernear":
 			{
 				_success = _completionArgs call DMS_fnc_IsPlayerNearby;

--- a/@ExileServer/addons/a3_dms/scripts/fn_MissionSuccessState.sqf
+++ b/@ExileServer/addons/a3_dms/scripts/fn_MissionSuccessState.sqf
@@ -35,8 +35,6 @@ private _exit = false;
             throw "ERROR";
         };
 
-        private _completionType = _x select 0;
-        private _completionArgs = _x select 1;
         private _absoluteWinCondition = _x param [2, false, [true]];
 
         if (!_success && {!_absoluteWinCondition}) then
@@ -53,21 +51,21 @@ private _exit = false;
         {
             case "kill":
             {
-                _success = _success && (_completionArgs call DMS_fnc_TargetsKilled);
+                _success = _completionArgs call DMS_fnc_TargetsKilled;
             };
             
             case "killpercent":
             {
-                _success = _success && (_completionArgs call DMS_fnc_TargetsKilledPercent);
+                _success = _completionArgs call DMS_fnc_TargetsKilledPercent;
             };
             
             case "playernear":
             {
-                _success = _success && (_completionArgs call DMS_fnc_IsPlayerNearby);
+                _success = _completionArgs call DMS_fnc_IsPlayerNearby;
             };
-            case "external":            // This is a special completion type. It is intended to be a flag for people who want to control mission completion using _onMonitorStart and _onMonitorEnd through array manipulation. You probably don't want to use this unless you know what you're doing.
+            case "external":
             {
-                _success = _success && _completionArgs;
+                _success = _completionArgs;
             };
             default
             {

--- a/@ExileServer/addons/a3_dms/scripts/fn_MissionSuccessState.sqf
+++ b/@ExileServer/addons/a3_dms/scripts/fn_MissionSuccessState.sqf
@@ -1,95 +1,92 @@
 /*
-	DMS_fnc_MissionSuccessState
-	Created by eraser1
+    DMS_fnc_MissionSuccessState
+    Created by eraser1
 
-	Usage:
-	[
-		[_completionType1,_completionArgs1,_isAbsoluteCondition],
-		[_completionType2,_completionArgs2,_isAbsoluteCondition],
-		...
-		[_completionTypeN,_completionArgsN,_isAbsoluteCondition]
-	] call DMS_fnc_MissionSuccessState;
+    Usage:
+    [
+        [_completionType1,_completionArgs1,_isAbsoluteCondition],
+        [_completionType2,_completionArgs2,_isAbsoluteCondition],
+        ...
+        [_completionTypeN,_completionArgsN,_isAbsoluteCondition]
+    ] call DMS_fnc_MissionSuccessState;
 */
 
 if !(_this isEqualType []) exitWith
 {
-	diag_log format ["DMS ERROR :: DMS_fnc_MissionSuccessState called with invalid parameter: %1",_this];
+    diag_log format ["DMS ERROR :: DMS_fnc_MissionSuccessState called with invalid parameter: %1",_this];
 };
 
 private _success = true;
 private _exit = false;
 
 {
-	if (_exit) exitWith {};
+    if (_exit) exitWith {};
 
-	try
-	{
-		if !(_x params
-		[
-			"_completionType",
-			"_completionArgs"
-		])
-		then
-		{
-			diag_log format ["DMS ERROR :: DMS_fnc_MissionSuccessState has invalid parameters in: %1",_x];
-			throw "ERROR";
-		};
+    try
+    {
+        if !(_x params
+        [
+            "_completionType",
+            "_completionArgs"
+        ])
+        then
+        {
+            diag_log format ["DMS ERROR :: DMS_fnc_MissionSuccessState has invalid parameters in: %1",_x];
+            throw "ERROR";
+        };
 
+        private _absoluteWinCondition = _x param [2, false, [true]];
 
-		private _absoluteWinCondition = _x param [2, false, [true]];
+        if (!_success && {!_absoluteWinCondition}) then
+        {
+            throw format ["Skipping completion check for condition |%1|; Condition is not absolute and a previous condition has already been failed.",_x];
+        };
 
-		if (!_success && {!_absoluteWinCondition}) then
-		{
-			throw format ["Skipping completion check for condition |%1|; Condition is not absolute and a previous condition has already been failed.",_x];
-		};
+        if (DMS_DEBUG) then
+        {
+            (format ["MissionSuccessState :: Checking completion type ""%1"" with argument |%2|. Absolute: %3",_completionType,_completionArgs,_absoluteWinCondition]) call DMS_fnc_DebugLog;
+        };
 
+        switch (toLower _completionType) do
+        {
+            case "kill":
+            {
+                _success = _success && (_completionArgs call DMS_fnc_TargetsKilled);
+            };
+            
+            case "killpercent":
+            {
+                _success = _success && (_completionArgs call DMS_fnc_TargetsKilledPercent);
+            };
+            
+            case "playernear":
+            {
+                _success = _success && (_completionArgs call DMS_fnc_IsPlayerNearby);
+            };
+            case "external":            // This is a special completion type. It is intended to be a flag for people who want to control mission completion using _onMonitorStart and _onMonitorEnd through array manipulation. You probably don't want to use this unless you know what you're doing.
+            {
+                _success = _success && _completionArgs;
+            };
+            default
+            {
+                diag_log format ["DMS ERROR :: Invalid completion type (%1) with args: %2",_completionType,_completionArgs];
+                throw "ERROR";
+            };
+        };
 
-		if (DMS_DEBUG) then
-		{
-			(format ["MissionSuccessState :: Checking completion type ""%1"" with argument |%2|. Absolute: %3",_completionType,_completionArgs,_absoluteWinCondition]) call DMS_fnc_DebugLog;
-		};
-
-		switch (toLower _completionType) do
-		{
-			case "kill":
-			{
-				_success = _completionArgs call DMS_fnc_TargetsKilled;
-			};
-			
-			case "killpercent":
-			{
-				_success = _completionArgs call DMS_fnc_TargetsKilledPercent;
-			};
-			
-			case "playernear":
-			{
-				_success = _completionArgs call DMS_fnc_IsPlayerNearby;
-			};
-			case "external":			// This is a special completion type. It is intended to be a flag for people who want to control mission completion using _onMonitorStart and _onMonitorEnd through array manipulation. You probably don't want to use this unless you know what you're doing.
-			{
-				_success = _completionArgs;
-			};
-			default
-			{
-				diag_log format ["DMS ERROR :: Invalid completion type (%1) with args: %2",_completionType,_completionArgs];
-				throw "ERROR";
-			};
-		};
-
-
-		if (_success && {_absoluteWinCondition}) then
-		{
-			_exit = true;
-			throw format ["Mission completed because of absolute win condition: %1",_x];
-		};
-	}
-	catch
-	{
-		if (DMS_DEBUG) then
-		{
-			(format ["MissionSuccessState :: %1",_exception]) call DMS_fnc_DebugLog;
-		};
-	};
+        if (_success && {_absoluteWinCondition}) then
+        {
+            _exit = true;
+            throw format ["Mission completed because of absolute win condition: %1",_x];
+        };
+    }
+    catch
+    {
+        if (DMS_DEBUG) then
+        {
+            (format ["MissionSuccessState :: %1",_exception]) call DMS_fnc_DebugLog;
+        };
+    };
 } forEach _this;
 
 _success;

--- a/@ExileServer/addons/a3_dms/scripts/fn_TargetsKilledPercent.sqf
+++ b/@ExileServer/addons/a3_dms/scripts/fn_TargetsKilledPercent.sqf
@@ -23,28 +23,28 @@ private _killedpercent = false;
 
 // Get the kill percent value from config
 private _killPercent = DMS_AI_KillPercent;
-//diag_log format ["DMS DEBUG :: Kill percent value: %1", _killPercent];
-//diag_log format ["DMS DEBUG :: Initial unit count: %1", _initialUnitCount];
+diag_log format ["DMS DEBUG :: Kill percent value: %1", _killPercent];
+diag_log format ["DMS DEBUG :: Initial unit count: %1", _initialUnitCount];
 
 // Calculate the acceptable number of killed units based on initial unit count
 private _unitsThreshold = ceil(_killPercent * _initialUnitCount / 100);
-//diag_log format ["DMS DEBUG :: Units threshold (killed units): %1", _unitsThreshold];
+diag_log format ["DMS DEBUG :: Units threshold (killed units): %1", _unitsThreshold];
 
 // Get all living AI units
 private _allUnits = _args call DMS_fnc_GetAllUnits;
 private _totalUnits = count _allUnits;
-//diag_log format ["DMS DEBUG :: Total living units: %1", _totalUnits];
+diag_log format ["DMS DEBUG :: Total living units: %1", _totalUnits];
 
 // Calculate the number of killed units
 private _killedUnits = if (_initialUnitCount - _totalUnits > 0) then {_initialUnitCount - _totalUnits} else {0};
-//diag_log format ["DMS DEBUG :: Total killed units: %1", _killedUnits];
+diag_log format ["DMS DEBUG :: Total killed units: %1", _killedUnits];
 
 // Check if the number of killed units is greater than or equal to the threshold
 if (_killedUnits >= _unitsThreshold) then {
     _killedpercent = true;
-    //diag_log "DMS DEBUG :: Kill percent condition met";
+    diag_log "DMS DEBUG :: Kill percent condition met";
 } else {
-    //diag_log "DMS DEBUG :: Kill percent condition not met";
+    diag_log "DMS DEBUG :: Kill percent condition not met";
 };
 
 _killedpercent;

--- a/@ExileServer/addons/a3_dms/scripts/fn_TargetsKilledPercent.sqf
+++ b/@ExileServer/addons/a3_dms/scripts/fn_TargetsKilledPercent.sqf
@@ -23,28 +23,28 @@ private _killedpercent = false;
 
 // Get the kill percent value from config
 private _killPercent = DMS_AI_KillPercent;
-//diag_log format ["DMS DEBUG :: Kill percent value: %1", _killPercent];
-//diag_log format ["DMS DEBUG :: Initial unit count: %1", _initialUnitCount];
+diag_log format ["DMS DEBUG :: Kill percent value: %1", _killPercent];
+diag_log format ["DMS DEBUG :: Initial unit count: %1", _initialUnitCount];
 
 // Calculate the acceptable number of killed units based on initial unit count
 private _unitsThreshold = ceil(_killPercent * _initialUnitCount / 100);
-//diag_log format ["DMS DEBUG :: Units threshold (killed units): %1", _unitsThreshold];
+diag_log format ["DMS DEBUG :: Units threshold (killed units): %1", _unitsThreshold];
 
 // Get all living AI units
 private _allUnits = _args call DMS_fnc_GetAllUnits;
 private _totalUnits = count _allUnits;
-//diag_log format ["DMS DEBUG :: Total living units: %1", _totalUnits];
+diag_log format ["DMS DEBUG :: Total living units: %1", _totalUnits];
 
 // Calculate the number of killed units
-private _killedUnits = _initialUnitCount - _totalUnits;
-//diag_log format ["DMS DEBUG :: Total killed units: %1", _killedUnits];
+private _killedUnits = if (_initialUnitCount - _totalUnits > 0) then {_initialUnitCount - _totalUnits} else {0};
+diag_log format ["DMS DEBUG :: Total killed units: %1", _killedUnits];
 
 // Check if the number of killed units is greater than or equal to the threshold
 if (_killedUnits >= _unitsThreshold) then {
     _killedpercent = true;
-    //diag_log "DMS DEBUG :: Kill percent condition met";
+    diag_log "DMS DEBUG :: Kill percent condition met";
 } else {
-    //diag_log "DMS DEBUG :: Kill percent condition not met";
+    diag_log "DMS DEBUG :: Kill percent condition not met";
 };
 
 _killedpercent;

--- a/@ExileServer/addons/a3_dms/scripts/fn_TargetsKilledPercent.sqf
+++ b/@ExileServer/addons/a3_dms/scripts/fn_TargetsKilledPercent.sqf
@@ -23,28 +23,28 @@ private _killedpercent = false;
 
 // Get the kill percent value from config
 private _killPercent = DMS_AI_KillPercent;
-diag_log format ["DMS DEBUG :: Kill percent value: %1", _killPercent];
-diag_log format ["DMS DEBUG :: Initial unit count: %1", _initialUnitCount];
+//diag_log format ["DMS DEBUG :: Kill percent value: %1", _killPercent];
+//diag_log format ["DMS DEBUG :: Initial unit count: %1", _initialUnitCount];
 
 // Calculate the acceptable number of killed units based on initial unit count
 private _unitsThreshold = ceil(_killPercent * _initialUnitCount / 100);
-diag_log format ["DMS DEBUG :: Units threshold (killed units): %1", _unitsThreshold];
+//diag_log format ["DMS DEBUG :: Units threshold (killed units): %1", _unitsThreshold];
 
 // Get all living AI units
 private _allUnits = _args call DMS_fnc_GetAllUnits;
 private _totalUnits = count _allUnits;
-diag_log format ["DMS DEBUG :: Total living units: %1", _totalUnits];
+//diag_log format ["DMS DEBUG :: Total living units: %1", _totalUnits];
 
 // Calculate the number of killed units
 private _killedUnits = if (_initialUnitCount - _totalUnits > 0) then {_initialUnitCount - _totalUnits} else {0};
-diag_log format ["DMS DEBUG :: Total killed units: %1", _killedUnits];
+//diag_log format ["DMS DEBUG :: Total killed units: %1", _killedUnits];
 
 // Check if the number of killed units is greater than or equal to the threshold
 if (_killedUnits >= _unitsThreshold) then {
     _killedpercent = true;
-    diag_log "DMS DEBUG :: Kill percent condition met";
+    //diag_log "DMS DEBUG :: Kill percent condition met";
 } else {
-    diag_log "DMS DEBUG :: Kill percent condition not met";
+    //diag_log "DMS DEBUG :: Kill percent condition not met";
 };
 
 _killedpercent;

--- a/@ExileServer/addons/a3_dms/scripts/fn_TargetsKilledPercent.sqf
+++ b/@ExileServer/addons/a3_dms/scripts/fn_TargetsKilledPercent.sqf
@@ -22,15 +22,21 @@ private _killedpercent = false;
 // Get the kill percent value from config
 private _killPercent = DMS_AI_KillPercent;
 
+// Static variable to store initial unit count
+if (isNil "DMS_initialUnitCount") then
+{
+    DMS_initialUnitCount = count (_this call DMS_fnc_GetAllUnits);
+};
+
+// Calculate the acceptable number of remaining units based on initial unit count
+private _unitsThreshold = floor((100 - _killPercent) * DMS_initialUnitCount / 100);
+
 // Get all living AI units
 private _allUnits = _this call DMS_fnc_GetAllUnits;
 private _totalUnits = count _allUnits;
 
-// Calculate the number of units that need to be killed
-private _unitsToKill = ceil((_killPercent / 100) * _totalUnits);
-
-// Check if the number of living units is less than or equal to the required kill percent
-if (_totalUnits <= _unitsToKill) then
+// Check if the number of living units is less than or equal to the threshold
+if (_totalUnits <= _unitsThreshold) then
 {
     _killedpercent = true;
 };

--- a/@ExileServer/addons/a3_dms/scripts/fn_TargetsKilledPercent.sqf
+++ b/@ExileServer/addons/a3_dms/scripts/fn_TargetsKilledPercent.sqf
@@ -23,28 +23,28 @@ private _killedpercent = false;
 
 // Get the kill percent value from config
 private _killPercent = DMS_AI_KillPercent;
-diag_log format ["DMS DEBUG :: Kill percent value: %1", _killPercent];
-diag_log format ["DMS DEBUG :: Initial unit count: %1", _initialUnitCount];
+//diag_log format ["DMS DEBUG :: Kill percent value: %1", _killPercent];
+//diag_log format ["DMS DEBUG :: Initial unit count: %1", _initialUnitCount];
 
 // Calculate the acceptable number of killed units based on initial unit count
 private _unitsThreshold = ceil(_killPercent * _initialUnitCount / 100);
-diag_log format ["DMS DEBUG :: Units threshold (killed units): %1", _unitsThreshold];
+//diag_log format ["DMS DEBUG :: Units threshold (killed units): %1", _unitsThreshold];
 
 // Get all living AI units
 private _allUnits = _args call DMS_fnc_GetAllUnits;
 private _totalUnits = count _allUnits;
-diag_log format ["DMS DEBUG :: Total living units: %1", _totalUnits];
+//diag_log format ["DMS DEBUG :: Total living units: %1", _totalUnits];
 
 // Calculate the number of killed units
 private _killedUnits = _initialUnitCount - _totalUnits;
-diag_log format ["DMS DEBUG :: Total killed units: %1", _killedUnits];
+//diag_log format ["DMS DEBUG :: Total killed units: %1", _killedUnits];
 
 // Check if the number of killed units is greater than or equal to the threshold
 if (_killedUnits >= _unitsThreshold) then {
     _killedpercent = true;
-    diag_log "DMS DEBUG :: Kill percent condition met";
+    //diag_log "DMS DEBUG :: Kill percent condition met";
 } else {
-    diag_log "DMS DEBUG :: Kill percent condition not met";
+    //diag_log "DMS DEBUG :: Kill percent condition not met";
 };
 
 _killedpercent;

--- a/@ExileServer/addons/a3_dms/scripts/fn_TargetsKilledPercent.sqf
+++ b/@ExileServer/addons/a3_dms/scripts/fn_TargetsKilledPercent.sqf
@@ -4,46 +4,47 @@
 
     Usage:
     [
+        _initialUnitCount,
         _unit,
         _group,
-        _object,
-        _threshold
+        _object
     ] call DMS_fnc_TargetsKilledPercent;
 
     Will accept non-array argument of group, unit, or object.
 */
 
-if (!(_this isEqualType [])) exitWith
-{
-    diag_log "DMS ERROR :: Calling DMS_TargetsKilled with non-array argument!";
+if (_this isEqualTo []) exitWith {
+    diag_log "DMS ERROR :: Calling DMS_TargetsKilled with empty array!";
 };
 
-if (count _this < 4) exitWith
-{
-    diag_log "DMS ERROR :: Calling DMS_TargetsKilled with insufficient parameters!";
-};
-
-private _unit = _this select 0;
-private _group = _this select 1;
-private _object = _this select 2;
-private _threshold = _this select 3;
-
+private _initialUnitCount = _this select 0;
+private _args = _this select [1, count _this - 1];
 private _killedpercent = false;
 
-// Получение значения DMS_AI_KillPercent из config.sqf
+// Get the kill percent value from config
 private _killPercent = DMS_AI_KillPercent;
+diag_log format ["DMS DEBUG :: Kill percent value: %1", _killPercent];
+diag_log format ["DMS DEBUG :: Initial unit count: %1", _initialUnitCount];
 
-// Получение всех живых AI юнитов
-private _allUnits = [_unit, _group, _object] call DMS_fnc_GetAllUnits;
+// Calculate the acceptable number of killed units based on initial unit count
+private _unitsThreshold = ceil(_killPercent * _initialUnitCount / 100);
+diag_log format ["DMS DEBUG :: Units threshold (killed units): %1", _unitsThreshold];
+
+// Get all living AI units
+private _allUnits = _args call DMS_fnc_GetAllUnits;
 private _totalUnits = count _allUnits;
+diag_log format ["DMS DEBUG :: Total living units: %1", _totalUnits];
 
-// Подсчет убитых юнитов
-private _killedUnits = _totalUnits - {alive _x} count _allUnits;
+// Calculate the number of killed units
+private _killedUnits = _initialUnitCount - _totalUnits;
+diag_log format ["DMS DEBUG :: Total killed units: %1", _killedUnits];
 
-// Проверка, если процент убитых юнитов больше или равен DMS_AI_KillPercent
-if ((_killedUnits / _totalUnits) * 100 >= _killPercent) then
-{
+// Check if the number of killed units is greater than or equal to the threshold
+if (_killedUnits >= _unitsThreshold) then {
     _killedpercent = true;
+    diag_log "DMS DEBUG :: Kill percent condition met";
+} else {
+    diag_log "DMS DEBUG :: Kill percent condition not met";
 };
 
 _killedpercent;

--- a/@ExileServer/addons/a3_dms/scripts/fn_TargetsKilledPercent.sqf
+++ b/@ExileServer/addons/a3_dms/scripts/fn_TargetsKilledPercent.sqf
@@ -35,7 +35,4 @@ if (_totalUnits <= _unitsToKill) then
     _killedpercent = true;
 };
 
-// Log the result using DMS_fnc_DebugLog
-[_killedpercent, "Targets Killed Percent"] call DMS_fnc_DebugLog;
-
 _killedpercent;

--- a/@ExileServer/addons/a3_dms/scripts/fn_TargetsKilledPercent.sqf
+++ b/@ExileServer/addons/a3_dms/scripts/fn_TargetsKilledPercent.sqf
@@ -30,12 +30,18 @@ private _threshold = _this select 3;
 
 private _killedpercent = false;
 
-// Get all living AI units
+// Получение значения DMS_AI_KillPercent из config.sqf
+private _killPercent = DMS_AI_KillPercent;
+
+// Получение всех живых AI юнитов
 private _allUnits = [_unit, _group, _object] call DMS_fnc_GetAllUnits;
 private _totalUnits = count _allUnits;
 
-// Check if the number of living units is less than or equal to the threshold
-if (_totalUnits <= _threshold) then
+// Подсчет убитых юнитов
+private _killedUnits = _totalUnits - {alive _x} count _allUnits;
+
+// Проверка, если процент убитых юнитов больше или равен DMS_AI_KillPercent
+if ((_killedUnits / _totalUnits) * 100 >= _killPercent) then
 {
     _killedpercent = true;
 };

--- a/@ExileServer/addons/a3_dms/scripts/fn_TargetsKilledPercent.sqf
+++ b/@ExileServer/addons/a3_dms/scripts/fn_TargetsKilledPercent.sqf
@@ -6,37 +6,36 @@
     [
         _unit,
         _group,
-        _object
+        _object,
+        _threshold
     ] call DMS_fnc_TargetsKilledPercent;
 
     Will accept non-array argument of group, unit, or object.
 */
 
-if (_this isEqualTo []) exitWith
+if (!(_this isEqualType [])) exitWith
 {
-    diag_log "DMS ERROR :: Calling DMS_TargetsKilled with empty array!";
+    diag_log "DMS ERROR :: Calling DMS_TargetsKilled with non-array argument!";
 };
+
+if (count _this < 4) exitWith
+{
+    diag_log "DMS ERROR :: Calling DMS_TargetsKilled with insufficient parameters!";
+};
+
+private _unit = _this select 0;
+private _group = _this select 1;
+private _object = _this select 2;
+private _threshold = _this select 3;
 
 private _killedpercent = false;
 
-// Get the kill percent value from config
-private _killPercent = DMS_AI_KillPercent;
-
-// Static variable to store initial unit count
-if (isNil "DMS_initialUnitCount") then
-{
-    DMS_initialUnitCount = count (_this call DMS_fnc_GetAllUnits);
-};
-
-// Calculate the acceptable number of remaining units based on initial unit count
-private _unitsThreshold = floor((100 - _killPercent) * DMS_initialUnitCount / 100);
-
 // Get all living AI units
-private _allUnits = _this call DMS_fnc_GetAllUnits;
+private _allUnits = [_unit, _group, _object] call DMS_fnc_GetAllUnits;
 private _totalUnits = count _allUnits;
 
 // Check if the number of living units is less than or equal to the threshold
-if (_totalUnits <= _unitsThreshold) then
+if (_totalUnits <= _threshold) then
 {
     _killedpercent = true;
 };

--- a/@ExileServer/addons/a3_dms/scripts/fn_TargetsKilledPercent.sqf
+++ b/@ExileServer/addons/a3_dms/scripts/fn_TargetsKilledPercent.sqf
@@ -1,0 +1,41 @@
+/*
+    DMS_fnc_TargetsKilledPercent
+    Created by Ravenger2709
+
+    Usage:
+    [
+        _unit,
+        _group,
+        _object
+    ] call DMS_fnc_TargetsKilledPercent;
+
+    Will accept non-array argument of group, unit, or object.
+*/
+
+if (_this isEqualTo []) exitWith
+{
+    diag_log "DMS ERROR :: Calling DMS_TargetsKilled with empty array!";
+};
+
+private _killedpercent = false;
+
+// Get the kill percent value from config
+private _killPercent = DMS_AI_KillPercent;
+
+// Get all living AI units
+private _allUnits = _this call DMS_fnc_GetAllUnits;
+private _totalUnits = count _allUnits;
+
+// Calculate the number of units that need to be killed
+private _unitsToKill = ceil((_killPercent / 100) * _totalUnits);
+
+// Check if the number of living units is less than or equal to the required kill percent
+if (_totalUnits <= _unitsToKill) then
+{
+    _killedpercent = true;
+};
+
+// Log the result using DMS_fnc_DebugLog
+[_killedpercent, "Targets Killed Percent"] call DMS_fnc_DebugLog;
+
+_killedpercent;


### PR DESCRIPTION
Added DMS_fnc_TargetsKilledPercent function, to check alive bots and if count >= value in DMS_AI_KillPercent - go nect to playerNear condition and finish mission

Changed bandit.sqf mission to demonstrate function working.

Change DMS_fnc_MissionSuccessState function to work with new condition.